### PR TITLE
Fixed Issue #1

### DIFF
--- a/login_example.py
+++ b/login_example.py
@@ -22,7 +22,7 @@ def login():
     login_user = users.find_one({'name' : request.form['username']})
 
     if login_user:
-        if bcrypt.hashpw(request.form['pass'].encode('utf-8'), login_user['password'].encode('utf-8')) == login_user['password'].encode('utf-8'):
+        if bcrypt.hashpw(request.form['pass'].encode('utf-8'), login_user['password']) == login_user['password']:
             session['username'] = request.form['username']
             return redirect(url_for('index'))
 


### PR DESCRIPTION
Since we are storing the hashed value of passwords, when we retrieve it, the type is 'bytes'. No need for `login_user['password'].encode('utf-8')` ;encoding again with utf-8.